### PR TITLE
Add option to summarize report on CLI

### DIFF
--- a/bin/create-report-cli
+++ b/bin/create-report-cli
@@ -1,0 +1,55 @@
+#!/usr/bin/python3
+
+import glob
+import xml.etree.ElementTree as ET
+
+
+def get_summary(reports):
+    passed = failures = errors = skipped = total = 0
+    for f in reports:
+        try:
+            for event, elem in ET.iterparse(f, events=('start',)):
+                if elem.tag == 'testsuite':
+                    d = dict(elem.attrib)
+                    d['time'] = float(d['time'])
+                    d['tests'] = float(d['tests'])
+                    d['errors'] = float(d['errors'])
+                    d['failures'] = float(d['failures'])
+                    d['skipped'] = float(d['skipped'])
+                    d['passed'] = d['tests'] - (d['errors'] + d['failures'] + d['skipped'])
+                    print(d)
+                    #
+                    total += d["tests"]
+                    passed += d["passed"]
+                    failures += d["failures"]
+                    errors += d["errors"]
+        except Exception as e:
+            print(e)
+
+    print('===========================================')
+    print("Total cases: {}".format(total))
+    for name, nr in [("Passed", passed), ("Failures", failures), ("Errors", errors), ("Skipped", skipped)]:
+        pct = round((nr / total) * 100, 2)
+        print("{}: {} ({}%)".format(name, nr, pct))
+
+    failed_tests = failures + errors
+    if failed_tests > 0:
+        raise Exception("{} Terraform tests failed!".format(failed_tests))
+
+
+def main():
+    reports = glob.glob('build/tests/*.xml')
+    if not reports:
+        print('no reports, run bin/create-report first')
+        exit(1)
+
+    reports.sort()
+
+    print('===========================================')
+    get_summary(reports)
+    print('===========================================')
+    print()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds an additional script that shows a quick summary. It will also throw an error if any test has failed. This is the script currently in use in the Moto CI.

```
bin/create-report
bin/create-report-cli
```

Example output for a failing test suite can be found here:
https://github.com/spulec/moto/runs/3257612401?check_suite_focus=true

cc @whummer 
