### PR TITLE
Add tinybird report plugin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           submodules: 'true'
       - id: set-matrix
         #run: echo "matrix=$(python -m terraform_pytest.get_services ${{ github.event.inputs.services || 'ls-all' }})" >> $GITHUB_OUTPUT
-        run: echo "matrix=$(python -m terraform_pytest.get_services ${{ github.event.inputs.services || 'sqs, sns' }})" >> $GITHUB_OUTPUT # TODO: restore
+        run: echo "matrix=$(python -m terraform_pytest.get_services ${{ github.event.inputs.services || 'sqs,sns' }})" >> $GITHUB_OUTPUT # TODO: restore
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -55,6 +55,10 @@ jobs:
         go-version: '1.18.x'
         cache: true
         cache-dependency-path: terraform-provider-aws/go.sum
+
+    - uses: actions/checkout@v3
+      with:
+        repository: tinybirdco/pytest-tinybird
 
     - name: Set up Python 3.10.5
       uses: actions/setup-python@v4
@@ -83,10 +87,10 @@ jobs:
         python -m terraform_pytest.main build -s ${{ matrix.service_partition.service }}
         ls -la terraform-provider-aws/test-bin
 
+
     - name: Setup tinybird plugin
       run: |
         source .venv/bin/activate
-        git clone git@github.com:tinybirdco/pytest-tinybird.git
         cd pytest-tinybird
         python setup.py install
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           submodules: 'true'
       - id: set-matrix
         #run: echo "matrix=$(python -m terraform_pytest.get_services ${{ github.event.inputs.services || 'ls-all' }})" >> $GITHUB_OUTPUT
-        run: echo "matrix=$(python -m terraform_pytest.get_services ${{ github.event.inputs.services || 'sqs,sns' }})" >> $GITHUB_OUTPUT # TODO: restore
+        run: echo "matrix=$(python -m terraform_pytest.get_services ${{ github.event.inputs.services || 'sqs' }})" >> $GITHUB_OUTPUT # TODO: restore
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -59,6 +59,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: tinybirdco/pytest-tinybird
+        path: pytest-tinybird
 
     - name: Set up Python 3.10.5
       uses: actions/setup-python@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,10 @@ on:
   schedule:
     - cron: '0 19 * * 6'
 
+  pull_request:
+    branches:
+      - main #TODO: remove
+
   workflow_dispatch:
     inputs:
       services:
@@ -25,7 +29,8 @@ jobs:
         with:
           submodules: 'true'
       - id: set-matrix
-        run: echo "matrix=$(python -m terraform_pytest.get_services ${{ github.event.inputs.services || 'ls-all' }})" >> $GITHUB_OUTPUT
+        #run: echo "matrix=$(python -m terraform_pytest.get_services ${{ github.event.inputs.services || 'ls-all' }})" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(python -m terraform_pytest.get_services ${{ github.event.inputs.services || 'sqs, sns' }})" >> $GITHUB_OUTPUT # TODO: restore
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -78,6 +83,13 @@ jobs:
         python -m terraform_pytest.main build -s ${{ matrix.service_partition.service }}
         ls -la terraform-provider-aws/test-bin
 
+    - name: Setup tinybird plugin
+      run: |
+        source .venv/bin/activate
+        git clone git@github.com:tinybirdco/pytest-tinybird.git
+        cd pytest-tinybird
+        python setup.py install
+
     - name: Setup LocalStack
       env:
         LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
@@ -101,6 +113,13 @@ jobs:
       env:
         SERVICE: ${{ matrix.service_partition.service }}
         PARTITION: ${{ matrix.service_partition.partition }}
+        TINYBIRD_URL: https://api.tinybird.co
+        TINYBIRD_DATASOURCE: tf_tinybird_local_test # TODO: change to real datasource
+        TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}
+        CI_COMMIT_SHA: ${{ github.sha }}
+        CI_JOB_ID: ${{ github.job }}
+        CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        CI_JOB_NAME: ${{ github.job }}-${{ matrix.service_partition.service }}-${{ matrix.service_partition.partition }}
       run: |
         source .venv/bin/activate
         enable_pro=${{ inputs.enable-pro || 'true' }}
@@ -110,9 +129,9 @@ jobs:
         fi
         if [[ ${{ matrix.service_partition.partition }} == "All" ]] 
         then
-          python -m pytest --junitxml=target/reports/pytest.xml terraform-provider-aws/internal/service/${{ matrix.service_partition.service }} -s -v --ls-start --gather-metrics
+          python -m pytest --junitxml=target/reports/pytest.xml terraform-provider-aws/internal/service/${{ matrix.service_partition.service }} -s -v --ls-start --gather-metrics --report-to-tinybird
         else
-          python -m pytest --junitxml=target/reports/pytest.xml $(python terraform_pytest/get_tf_partitions.py ${{ matrix.service_partition.service }} ${{ matrix.service_partition.partition }} ) -s -v --ls-start --gather-metrics
+          python -m pytest --junitxml=target/reports/pytest.xml $(python terraform_pytest/get_tf_partitions.py ${{ matrix.service_partition.service }} ${{ matrix.service_partition.partition }} ) -s -v --ls-start --gather-metrics --report-to-tinybird
         fi
 
     - name: Archive Test Result

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,6 @@ on:
   schedule:
     - cron: '0 19 * * 6'
 
-  pull_request:
-    branches:
-      - main #TODO: remove
-
   workflow_dispatch:
     inputs:
       services:
@@ -29,8 +25,7 @@ jobs:
         with:
           submodules: 'true'
       - id: set-matrix
-        #run: echo "matrix=$(python -m terraform_pytest.get_services ${{ github.event.inputs.services || 'ls-all' }})" >> $GITHUB_OUTPUT
-        run: echo "matrix=$(python -m terraform_pytest.get_services ${{ github.event.inputs.services || 'sqs,sns' }})" >> $GITHUB_OUTPUT # TODO: restore
+        run: echo "matrix=$(python -m terraform_pytest.get_services ${{ github.event.inputs.services || 'ls-all' }})" >> $GITHUB_OUTPUT
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -119,7 +114,7 @@ jobs:
         SERVICE: ${{ matrix.service_partition.service }}
         PARTITION: ${{ matrix.service_partition.partition }}
         TINYBIRD_URL: https://api.tinybird.co
-        TINYBIRD_DATASOURCE: tf_tinybird_local_test # TODO: change to real datasource
+        TINYBIRD_DATASOURCE: localstack_terraform_test_results
         TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}
         CI_COMMIT_SHA: ${{ github.sha }}
         CI_JOB_ID: ${{ github.job }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           submodules: 'true'
       - id: set-matrix
         #run: echo "matrix=$(python -m terraform_pytest.get_services ${{ github.event.inputs.services || 'ls-all' }})" >> $GITHUB_OUTPUT
-        run: echo "matrix=$(python -m terraform_pytest.get_services ${{ github.event.inputs.services || 'sqs' }})" >> $GITHUB_OUTPUT # TODO: restore
+        run: echo "matrix=$(python -m terraform_pytest.get_services ${{ github.event.inputs.services || 'sqs,sns' }})" >> $GITHUB_OUTPUT # TODO: restore
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
This PR adds the tinybird report plugin to the CI, check [here](https://github.com/tinybirdco/pytest-tinybird)
This way, all test results are loaded into tinybird. The name of the data source is `localstack_terraform_test_results`