### PR TITLE
migrate to localstack auth login

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
           docker pull localstack/localstack
         else
           docker pull localstack/localstack-pro
-          localstack login -u $TMP_USER -p $TMP_PW  # login is currently required
+          localstack auth login -u $TMP_USER -p $TMP_PW  # login is currently required
           localstack extensions init
           localstack extensions install "git+https://github.com/localstack/localstack-moto-test-coverage/#egg=collect-raw-metric-data-extension&subdirectory=collect-raw-metric-data-extension"
         fi


### PR DESCRIPTION
## Motivation
`localstack login` has been deprecated in favor of `localstack auth login` for quite a while (at least `3.0`).

## Changes
This PR changes the usages of `localstack login` in this repo to `localstack auth login`.