### PR TITLE
remove logout step from workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,12 +160,6 @@ jobs:
         name: test-metrics
         path: target/reports
 
-    - name: Logout LocalStack
-      if: ${{ (github.event.inputs.enable-pro || 'true') == 'true' }}
-      run: |
-        source .venv/bin/activate
-        localstack logout
-
     - name: Publish ${{ matrix.service }} Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()


### PR DESCRIPTION
The `logout` step is failing as the cli does not know the command:

![image](https://github.com/localstack/localstack-terraform-test/assets/5726672/24b927e4-32d1-44c1-8b6d-3f97b6925cc1)
